### PR TITLE
Critical Bug Fix for ajax-hook sometimes working sometimes not

### DIFF
--- a/hook_request.user.js
+++ b/hook_request.user.js
@@ -8,6 +8,7 @@
 // @match        *://www.youtube.com/*
 // @require      https://unpkg.com/ajax-hook@2.0.2/dist/ajaxhook.min.js
 // @grant        none
+// @run-at       document-start
 // @namespace    https://github.com/CoinkWang/Y2BDoubleSubs
 // ==/UserScript==
 


### PR DESCRIPTION
without setting `@run-at document-start`, the script will just work by luck

@CoinkWang 你沒有把這腳本設在頁面最初時運行的話，hook在要求之後就會發生不能正常使用的情況。加了`@run-at document-start` 就完美解決了這個執行與否靠運氣的問題